### PR TITLE
Feature/logout api

### DIFF
--- a/src/common/encryption/passwordEncryption.ts
+++ b/src/common/encryption/passwordEncryption.ts
@@ -17,9 +17,10 @@ export class PasswordEncryption {
   }
 
   async changedPasswordAfter(user: User, JWTTimestamp: number) {
-    if (user.passwordChangedAt) {
-      const changedTimeStamp = user.passwordChangedAt.getTime() / 1000;
-
+    if (user?.passwordChangedAt) {
+      const changedTimeStamp = Math.floor(
+        user.passwordChangedAt.getTime() / 1000,
+      );
       return JWTTimestamp < changedTimeStamp;
     }
 

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -14,6 +14,7 @@ import RequestWithUser from './local/requestWithUser.interface';
 import { CreateUserDto } from '../user/dtos/createUser.dto';
 import { ApiTags, ApiOperation, ApiResponse, ApiBody } from '@nestjs/swagger';
 import { loginUserDto } from '../auth/dtos/loginUser.dto';
+import { JwtAuthGuard } from './jwt/jwt.guard';
 
 @ApiTags('auth')
 @Controller()
@@ -60,6 +61,24 @@ export class AuthController {
     return res.send({
       message: 'register success',
       data: loggedInNewUser,
+    });
+  }
+
+  @HttpCode(200)
+  @Post('/logout')
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'User log out' })
+  @ApiResponse({ status: 200, description: 'Logout success' })
+  @ApiResponse({
+    status: 401,
+    description: 'Logout is possible only when the user is logged in',
+  })
+  async logout(@Res() res: Response): Promise<any> {
+    const { token, ...cookieOption } = await this.authService.logout();
+    res.cookie('jwt', token, cookieOption);
+
+    return res.send({
+      message: 'logout success',
     });
   }
 }

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -135,4 +135,13 @@ export class AuthService {
 
     return user;
   }
+
+  async logout() {
+    return {
+      token: '',
+      path: '/',
+      httpOnly: true,
+      maxAge: 0,
+    };
+  }
 }

--- a/src/modules/user/user.repository.ts
+++ b/src/modules/user/user.repository.ts
@@ -45,6 +45,9 @@ export class UserRepository {
         where: {
           id: userId,
         },
+        omit: {
+          passwordChangedAt: false,
+        },
       });
     } catch (error) {
       throw ServiceException.ErrorException(
@@ -115,6 +118,7 @@ export class UserRepository {
         },
         omit: {
           password: false,
+          passwordChangedAt: false,
         },
         where: {
           id: updateUserDto.id,

--- a/test/e2e/auth.e2e-spec.ts
+++ b/test/e2e/auth.e2e-spec.ts
@@ -15,10 +15,14 @@ import refreshDatabase from '../../src/prisma/prisma.dbreset';
 import { AppModule } from './../../src/app.module';
 import { ThrottlerGuard } from '@nestjs/throttler';
 import { RedisThrottlerStorageService } from '../../src/common/throttler/redisThrottlerStorage.service';
+import { PasswordEncryption } from '../../src/common/encryption/passwordEncryption';
+import { JwtStrategy } from '../../src/modules/auth/jwt/jwt.strategy';
 
 describe('/', () => {
   let app: INestApplication;
   let prismaService: PrismaService;
+  let passwordEncryption: PasswordEncryption;
+  let jwtStrategy: JwtStrategy;
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -42,6 +46,9 @@ describe('/', () => {
       .compile();
 
     prismaService = moduleFixture.get<PrismaService>(PrismaService);
+    passwordEncryption =
+      moduleFixture.get<PasswordEncryption>(PasswordEncryption);
+    jwtStrategy = moduleFixture.get<JwtStrategy>(JwtStrategy);
     app = moduleFixture.createNestApplication();
     app.useGlobalPipes(
       new ValidationPipe({
@@ -215,5 +222,143 @@ describe('/', () => {
           message: errorMessages.INCORRECT_EMAIL_OR_PASSWORD,
         });
     });
+  });
+
+  describe('/logout POST (logout)', () => {
+    afterEach(async () => {
+      process.env.JWT_EXPIRES_IN = '90d'; // Reset to default expiration
+    });
+
+    it('should return a 200 if everything is fine', async () => {
+      // First register and login to get valid tokens
+      const registerResponse = await request(app.getHttpServer())
+        .post('/register')
+        .send(defaultCreateUserDto);
+
+      const token = registerResponse.headers.authorization.split(' ')[1];
+
+      await request(app.getHttpServer())
+        .post('/logout')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200)
+        .expect({
+          message: 'logout success',
+        });
+    });
+
+    it('should return 401 if user is not logged in', async () => {
+      // Direct logout attempt without login
+      await request(app.getHttpServer()).post('/logout').expect(401).expect({
+        statusCode: 401,
+        message: errorMessages.PROTECT_ROUTES,
+      });
+    });
+
+    it('should return 401 if JWT token is invalid', async () => {
+      await request(app.getHttpServer())
+        .post('/logout')
+        .set('Authorization', 'Bearer invalid-token')
+        .expect(401)
+        .expect({
+          statusCode: 401,
+          message: errorMessages.INVALID_TOKEN,
+        });
+    });
+
+    it('should return 401 if JWT token is expired', async () => {
+      // Store original expiration
+      const originalExpiration = process.env.JWT_EXPIRES_IN;
+
+      // Set very short expiration
+      process.env.JWT_EXPIRES_IN = '1s';
+
+      // Create new app instance with updated JWT config
+      const moduleFixture: TestingModule = await Test.createTestingModule({
+        imports: [
+          AppModule,
+          AuthModule,
+          UserModule,
+          PrismaModule.forTest(prisma),
+        ],
+        providers: [ConfigService],
+      })
+        .overrideProvider(ThrottlerGuard)
+        .useValue({ canActivate: () => true })
+        .overrideProvider(RedisThrottlerStorageService)
+        .useValue({
+          get: jest.fn().mockResolvedValue(null),
+          set: jest.fn(),
+        })
+        .compile();
+
+      const newApp = moduleFixture.createNestApplication();
+      await newApp.init();
+
+      // Register to get a token
+      const registerResponse = await request(newApp.getHttpServer())
+        .post('/register')
+        .send(defaultCreateUserDto);
+
+      const token = registerResponse.headers.authorization.split(' ')[1];
+
+      // Wait for token to expire
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+
+      // Try logout with expired token
+      const response = await request(newApp.getHttpServer())
+        .post('/logout')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(401);
+
+      expect(response.body).toEqual({
+        statusCode: 401,
+        message: errorMessages.TOKEN_EXPIRED,
+      });
+
+      // Cleanup
+      process.env.JWT_EXPIRES_IN = originalExpiration;
+      await newApp.close();
+    }, 10000);
+
+    it('should return 401 if user changed password after token was issued', async () => {
+      // Register and get token
+      const registerResponse = await request(app.getHttpServer())
+        .post('/register')
+        .send(defaultCreateUserDto);
+
+      const token = registerResponse.headers.authorization.split(' ')[1];
+      const userId = registerResponse.body.data.id;
+
+      // Decode the token to get the issue time (iat)
+      const decodedToken = await jwtStrategy.verifyAndDecodeToken(token);
+      const tokenIssueTime = decodedToken.iat;
+
+      // Generate new password hash
+      const { hashedPassword: newPassword } =
+        await passwordEncryption.createSaltAndHashedPassword('newPassword');
+
+      // Set password change time to a time after the token was issued
+      const passwordChangedAt = new Date((tokenIssueTime + 10) * 1000); // 10 seconds after
+
+      // Update user with new password and change time
+      await prismaService.user.update({
+        where: { id: userId },
+        data: {
+          password: newPassword,
+          passwordChangedAt: passwordChangedAt,
+        },
+      });
+
+      // Try logout with old token
+      const response = await request(app.getHttpServer())
+        .post('/logout')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(401);
+
+      expect(response.body).toEqual({
+        statusCode: 401,
+        message: errorMessages.USER_CHANGED_PASSWORD,
+      });
+    }, 10000);
   });
 });

--- a/test/unit/modules/auth/auth.controller.spec.ts
+++ b/test/unit/modules/auth/auth.controller.spec.ts
@@ -3,9 +3,9 @@ import { Test, TestingModule } from '@nestjs/testing';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const httpMocks = require('node-mocks-http');
 import { JwtModule } from '@nestjs/jwt';
-import { PasswordEncryption } from '../../../../src/common/encryption/passwordEncryption';
 import {
   defaultCreateUserDto,
+  defaultUser,
   defaultUserResponseDto,
 } from '../../../utils/user.utils';
 import { AuthController } from '../../../../src/modules/auth/auth.controller';
@@ -19,35 +19,18 @@ import { PassportModule } from '@nestjs/passport';
 import { UserService } from '../../../../src/modules/user/user.service';
 import { UserRepository } from '../../../../src/modules/user/user.repository';
 import { UserMapper } from '../../../../src/modules/user/dtos/user.mapper';
-import { JwtAuthGuard } from '../../../../src/modules/auth/jwt/jwt.guard';
 import { JwtStrategy } from '../../../../src/modules/auth/jwt/jwt.strategy';
 import { errorMessages } from '../../../../src/common/enums/errorMessages';
 import { ServiceException } from '../../../../src/common/exception-filter/serviceException';
+import { PasswordEncryption } from '../../../../src/common/encryption/passwordEncryption';
 
 describe('AuthController', () => {
   let authController: AuthController;
   let authService: AuthService;
-  let userRepository: UserRepository;
-
-  const mockUserRepository = {
-    getUserById: jest.fn().mockResolvedValue(defaultUserResponseDto),
-    getUserByEmail: jest.fn().mockResolvedValue(defaultUserResponseDto),
-    createUser: jest.fn().mockResolvedValue(defaultUserResponseDto),
-  };
-
-  const mockJwtStrategy = {
-    validate: jest.fn().mockResolvedValue(defaultUserResponseDto),
-    checkUserExistsInDB: jest.fn().mockResolvedValue(defaultUserResponseDto),
-    checkTokenExists: jest.fn().mockReturnValue('valid-token'),
-    verifyAndDecodeToken: jest.fn().mockResolvedValue({
-      id: defaultUserResponseDto.id,
-      iat: Date.now() / 1000,
-    }),
-    checkUserPasswordChanged: jest.fn().mockResolvedValue(undefined),
-  };
+  let jwtStrategy: JwtStrategy;
 
   beforeAll(async () => {
-    const app: TestingModule = await Test.createTestingModule({
+    const module: TestingModule = await Test.createTestingModule({
       imports: [
         PrismaModule.forTest(prisma),
         ConfigModule.forRoot({ isGlobal: true }),
@@ -65,29 +48,21 @@ describe('AuthController', () => {
       controllers: [AuthController],
       providers: [
         UserService,
-        {
-          provide: UserRepository,
-          useValue: mockUserRepository,
-        },
-        UserMapper,
+        UserRepository,
         PasswordEncryption,
+        UserMapper,
         AuthService,
         ConfigService,
-        {
-          provide: JwtStrategy,
-          useValue: mockJwtStrategy,
-        },
+        JwtStrategy,
       ],
     })
       .overrideGuard(LocalAuthGuard)
       .useValue({ canActivate: jest.fn().mockReturnValue(true) })
-      .overrideGuard(JwtAuthGuard)
-      .useValue({ canActivate: jest.fn().mockReturnValue(true) })
       .compile();
 
-    authController = app.get<AuthController>(AuthController);
-    authService = app.get<AuthService>(AuthService);
-    userRepository = app.get<UserRepository>(UserRepository);
+    authController = module.get<AuthController>(AuthController);
+    authService = module.get<AuthService>(AuthService);
+    jwtStrategy = module.get<JwtStrategy>(JwtStrategy);
   });
 
   beforeEach(() => {
@@ -147,6 +122,144 @@ describe('AuthController', () => {
         message: 'register success',
         data: defaultUserResponseDto,
       });
+    });
+  });
+
+  describe('logout function', () => {
+    let res: any;
+
+    beforeEach(() => {
+      res = httpMocks.createResponse();
+      jest.clearAllMocks();
+
+      // Mock AuthService
+      jest.spyOn(authService, 'logout').mockResolvedValue({
+        token: '',
+        path: '/',
+        httpOnly: true,
+        maxAge: 0,
+      });
+    });
+
+    it('should handle missing token', async () => {
+      const req = httpMocks.createRequest();
+
+      // Mock JwtStrategy to throw error
+      const error = ServiceException.UnAuthorizedException(
+        errorMessages.PROTECT_ROUTES,
+      );
+      jest.spyOn(jwtStrategy, 'checkTokenExists').mockImplementation(() => {
+        throw error;
+      });
+
+      try {
+        await jwtStrategy.validate(req);
+        await authController.logout(res);
+      } catch (e) {
+        expect(e).toBeInstanceOf(ServiceException);
+        expect(e.message).toBe(errorMessages.PROTECT_ROUTES);
+      }
+
+      expect(authService.logout).not.toHaveBeenCalled();
+    });
+
+    it('should handle expired token', async () => {
+      const req = httpMocks.createRequest();
+      const error = ServiceException.UnAuthorizedException(
+        errorMessages.TOKEN_EXPIRED,
+      );
+
+      jest
+        .spyOn(jwtStrategy, 'checkTokenExists')
+        .mockReturnValue('expired-token');
+      jest.spyOn(jwtStrategy, 'verifyAndDecodeToken').mockImplementation(() => {
+        throw error;
+      });
+
+      try {
+        await jwtStrategy.validate(req);
+        await authController.logout(res);
+      } catch (e) {
+        expect(e).toBeInstanceOf(ServiceException);
+        expect(e.message).toBe(errorMessages.TOKEN_EXPIRED);
+      }
+
+      expect(jwtStrategy.checkTokenExists).toHaveBeenCalled();
+      expect(jwtStrategy.verifyAndDecodeToken).toHaveBeenCalledWith(
+        'expired-token',
+      );
+      expect(authService.logout).not.toHaveBeenCalled();
+    });
+
+    it('should handle non-existent user', async () => {
+      const req = httpMocks.createRequest();
+      const error = ServiceException.UnAuthorizedException(
+        errorMessages.ENTITY_NOT_FOUND('User', '9999'),
+      );
+
+      jest
+        .spyOn(jwtStrategy, 'checkTokenExists')
+        .mockReturnValue('valid-token');
+      jest
+        .spyOn(jwtStrategy, 'verifyAndDecodeToken')
+        .mockResolvedValue({ id: 9999 });
+      jest.spyOn(jwtStrategy, 'checkUserExistsInDB').mockImplementation(() => {
+        throw error;
+      });
+
+      try {
+        await jwtStrategy.validate(req);
+        await authController.logout(res);
+      } catch (e) {
+        expect(e).toBeInstanceOf(ServiceException);
+        expect(e.message).toBe(errorMessages.ENTITY_NOT_FOUND('User', '9999'));
+      }
+
+      expect(jwtStrategy.checkTokenExists).toHaveBeenCalled();
+      expect(jwtStrategy.verifyAndDecodeToken).toHaveBeenCalledWith(
+        'valid-token',
+      );
+      expect(jwtStrategy.checkUserExistsInDB).toHaveBeenCalledWith(9999);
+      expect(authService.logout).not.toHaveBeenCalled();
+    });
+
+    it('should handle password changed scenario', async () => {
+      const req = httpMocks.createRequest();
+      const error = ServiceException.UnAuthorizedException(
+        errorMessages.USER_CHANGED_PASSWORD,
+      );
+
+      jest
+        .spyOn(jwtStrategy, 'checkTokenExists')
+        .mockReturnValue('valid-token');
+      jest.spyOn(jwtStrategy, 'verifyAndDecodeToken').mockResolvedValue({
+        id: defaultUser.id,
+        iat: Date.now() / 1000,
+      });
+      jest
+        .spyOn(jwtStrategy, 'checkUserExistsInDB')
+        .mockResolvedValue(defaultUser);
+      jest
+        .spyOn(jwtStrategy, 'checkUserPasswordChanged')
+        .mockImplementation(() => {
+          throw error;
+        });
+
+      try {
+        await jwtStrategy.validate(req);
+        await authController.logout(res);
+      } catch (e) {
+        expect(e).toBeInstanceOf(ServiceException);
+        expect(e.message).toBe(errorMessages.USER_CHANGED_PASSWORD);
+      }
+
+      expect(jwtStrategy.checkTokenExists).toHaveBeenCalledTimes(1);
+      expect(jwtStrategy.verifyAndDecodeToken).toHaveBeenCalledWith(
+        'valid-token',
+      );
+      expect(jwtStrategy.checkUserExistsInDB).toHaveBeenCalled();
+      expect(jwtStrategy.checkUserPasswordChanged).toHaveBeenCalled();
+      expect(authService.logout).not.toHaveBeenCalled();
     });
   });
 

--- a/test/unit/modules/auth/auth.service.spec.ts
+++ b/test/unit/modules/auth/auth.service.spec.ts
@@ -276,4 +276,17 @@ describe('AuthService', () => {
       expect(res.cookies.jwt.value).toBeDefined();
     });
   });
+
+  describe('logout function', () => {
+    it('should return logout options object', async () => {
+      const logoutOptions = await authService.logout();
+
+      expect(logoutOptions).toEqual({
+        token: '',
+        path: '/',
+        httpOnly: true,
+        maxAge: 0,
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Related Issue

- create a logout api

## Description

created logout api logic and add unit tests and e2e test for logout api so that user can successfully logout from thinkstorm.
Also, jwt token related logic was dealt with here.

## Details

1. create a logout api
<hr/>
  I considered 6 cases for this api

  - [x] when the user is logged in, logout should be successful
  - [x] when the user is not logged in, logout should be fail (jwt token doesn't exist)
  - when the user has jwt token, but...
      - [x] token is expired
      - [x] token is invalid
      - [x] user doesn't exist anymore
      - [x] user's password was changed

then it should fail.
<hr/>

According to this logic, I changed related logic such as 
- [x] fix user repository getUserId (for getting passwordChangedAt field)
- [x] refactor userRepository update user function omit(passwordChangedAt: false) so that user can see when the password was changed after updating
- [x] refactor for passwordEncryption.changedPasswordAfter Math.floor part (for getting the exact value)
- [x] add auth controller logout function
- [x] add auth service logout function

<hr/>
2. add unit test for logout api

- [x] tested each case mentioned above for logout api
<hr/>
3. add e2e test for logout api

- [x] tested each case mentioned above for logout api
<hr/>

## Reviewers

- @Harian-Elyoth 
- @minju25kim 
