### PR TITLE
feat: add prettier and tsc verifications

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,14 @@
+# Run lint-staged
 npx --no-install lint-staged
-npx prettier -w . --log-level silent
+
+# Run ESLint on staged files
+echo "Running ESLint on staged files..."
+git diff --cached --name-only --diff-filter=ACMR | grep -E '\.(js|jsx|ts|tsx)$' | xargs -r npx eslint --max-warnings=0 || exit 1
+
+# Run Prettier
+echo "Running Prettier..."
+npx prettier -w . --log-level silent || exit 1
+
+# Run TypeScript type checking
+echo "Running TypeScript type checking..."
+npx tsc --noEmit || exit 1


### PR DESCRIPTION
## Related Issue

- 86c33tafq On click up : https://app.clickup.com/t/86c33tafq

## Description

- In the new ci/cd pipeline there are verifications that are more robust than the local one. In order to pass on ci/cd verification such prettier and tsc I added them into the husky pre-commit hooks.


## Reviewers

- You can tag here (@kimdahee0815 @minju25kim ) the reviewers for that pull request
