### PR TITLE
Feature/47 save project api

### DIFF
--- a/prisma/migrations/20250618011639_add_saved_projects/migration.sql
+++ b/prisma/migrations/20250618011639_add_saved_projects/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "saved_projects" (
+    "user_id" INTEGER NOT NULL,
+    "project_id" INTEGER NOT NULL,
+    "savedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "saved_projects_pkey" PRIMARY KEY ("user_id","project_id")
+);
+
+-- AddForeignKey
+ALTER TABLE "saved_projects" ADD CONSTRAINT "saved_projects_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "saved_projects" ADD CONSTRAINT "saved_projects_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,6 +26,7 @@ model User {
   fullName          String?        @map("full_name")
   birthdate         DateTime?
   founded_projects  Project[]      @relation("FounderProjects")
+  savedProjects     SavedProject[]
   projects          Project[]
   like              Like[]
   involvement       Involvement[]
@@ -61,13 +62,14 @@ model Project {
   description     String?
   goal            String
   status          String
-  languageCode    String            @map("language_code")
+  languageCode    String                  @map("language_code")
   milestone       DateTime?
   createdAt       DateTime                @default(now()) @map("created_at")
   lastUpdatedAt   DateTime                @updatedAt @map("last_updated_at")
   founder         User?                   @relation(fields: [founderId], references: [id], name: "FounderProjects", onDelete: SetNull)
   language        Language?               @relation(fields: [languageCode], references: [code], onDelete: SetNull)
   users           User[]
+  savedByUsers    SavedProject[]
   domainLabels    ProjectDomainLabel[]
   technicalLabels ProjectTechnicalLabel[]
   like            Like[]
@@ -105,6 +107,18 @@ model DomainLabel {
   users    UserProfileDomainLabel[]
 
   @@map("domain_labels")
+}
+
+model SavedProject {
+  userId    Int      @map("user_id")
+  projectId Int      @map("project_id")
+  savedAt   DateTime @default(now())
+
+  user      User     @relation(fields: [userId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+  project   Project?  @relation(fields: [projectId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+
+  @@id([userId, projectId])
+  @@map("saved_projects")
 }
 
 model UserProfileDomainLabel {

--- a/src/common/enums/errorMessages.ts
+++ b/src/common/enums/errorMessages.ts
@@ -10,6 +10,8 @@ export const errorMessages = {
   ERROR_UPDATING_PROJECTS: 'An error occurred while updating project.',
   ERROR_DELETING_PROJECTS: 'An error occurred while deleting project.',
   ERROR_FINDING_PROJECTS: 'An error occurred while finding projects.',
+  ERROR_SAVING_PROJECTS: 'An error occurred while saving projects.',
+  USER_ALREADY_SAVED_PROJECT: 'User already saved the project.',
   ERROR_GETTING_USER_BY_EMAIL: 'An error occurred while getting user by email.',
   ERROR_GETTING_USER_BY_ID: 'An error occurred while getting user by id.',
   ERROR_CREATING_USER: 'An error occurred while creating user.',

--- a/src/modules/project/dtos/project.mapper.ts
+++ b/src/modules/project/dtos/project.mapper.ts
@@ -1,33 +1,10 @@
-import {
-  Project,
-  ProjectDomainLabel,
-  ProjectTechnicalLabel,
-  User,
-  Language,
-  Like,
-  Involvement,
-  JoinRequest,
-} from '@prisma/client';
+import { Project } from '@prisma/client';
 import { stringToEnum, Goal, ProjectStatus } from '@think-storm/contracts';
 import { ProjectResponseDto } from './projectResponse.dto';
 import { instanceToPlain, plainToInstance } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
 import { SearchProjectResponseDto } from './searchProjectResponse.dto';
-
-type ProjectWithLabels = Project & {
-  domainLabels?: (ProjectDomainLabel & {
-    label: { name: string };
-  })[];
-  technicalLabels?: (ProjectTechnicalLabel & {
-    label: { name: string };
-  })[];
-  language?: Language;
-  users?: User[];
-  founder?: User;
-  like?: Like[];
-  involvement?: Involvement[];
-  joinRequest?: JoinRequest[];
-};
+import { ProjectWithLabels } from '../types/project.types';
 
 export class ProjectMapper {
   /**
@@ -67,6 +44,11 @@ export class ProjectMapper {
     // Transform string status to enum
     if (plainProject.status) {
       plainProject.status = stringToEnum(plainProject.status, ProjectStatus);
+    }
+
+    // Transform saved by users array if they exist and have the complex structure
+    if (project.savedByUsers?.length > 0 && 'user' in project.savedByUsers[0]) {
+      plainProject.savedByUsers = project.savedByUsers.map((user) => user.user);
     }
 
     return plainToInstance(ProjectResponseDto, plainProject, {

--- a/src/modules/project/dtos/projectResponse.dto.ts
+++ b/src/modules/project/dtos/projectResponse.dto.ts
@@ -100,4 +100,10 @@ export class ProjectResponseDto implements ProjectResponse {
     description: 'The last update date of the project',
   })
   lastUpdatedAt: Date;
+
+  @Expose()
+  @ApiProperty({
+    description: 'The users array that saved current project',
+  })
+  savedByUsers?: User[];
 }

--- a/src/modules/project/dtos/saveProjectRequest.dto.ts
+++ b/src/modules/project/dtos/saveProjectRequest.dto.ts
@@ -1,0 +1,12 @@
+import { PartialType, ApiProperty } from '@nestjs/swagger';
+import { UpdateProjectRequestDto } from './updateProjectRequest.dto';
+import { IsArray, IsInt } from 'class-validator';
+
+export class SaveProjectRequestDto extends PartialType(
+  UpdateProjectRequestDto,
+) {
+  @ApiProperty({ required: true, isArray: true })
+  @IsArray()
+  @IsInt({ each: true })
+  saved_by_users: number[];
+}

--- a/src/modules/project/project.controller.ts
+++ b/src/modules/project/project.controller.ts
@@ -26,6 +26,7 @@ import {
 import { JwtAuthGuard } from '../auth/jwt/jwt.guard';
 import { GetUser } from '../auth/decorators/getUser.decorator';
 import { SearchProjectResponseDto } from './dtos/searchProjectResponse.dto';
+import { SaveProjectRequestDto } from './dtos/saveProjectRequest.dto';
 
 @ApiTags('projects')
 @Controller()
@@ -35,6 +36,7 @@ export class ProjectController {
   @HttpCode(200)
   @Get('search')
   @ApiOperation({ summary: 'Get projects filtered by query string' })
+  @ApiBody({ type: SearchProjectDto })
   @ApiResponse({
     status: 200,
     description: 'Get projects filtered by query success',
@@ -138,5 +140,36 @@ export class ProjectController {
     @GetUser() user: any,
   ) {
     return await this.projectService.deleteProject(deleteProjectDto, user.id);
+  }
+
+  @HttpCode(201)
+  @Post(':id/save')
+  @ApiOperation({ summary: 'Save projects' })
+  @ApiParam({ name: 'id', required: true, description: 'Project ID' })
+  @ApiBody({ type: UpdateProjectRequestDto })
+  @ApiResponse({
+    status: 201,
+    description: 'Save project success',
+    type: ProjectResponseDto,
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden. User can save the project only once.',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Project or User not found',
+  })
+  @UseGuards(JwtAuthGuard)
+  async saveProject(
+    @Param('id') projectId: number,
+    @Body() saveProjectDto: SaveProjectRequestDto,
+    @GetUser() user: any,
+  ): Promise<ProjectResponseDto> {
+    return await this.projectService.saveProject(
+      +projectId,
+      saveProjectDto,
+      user.id,
+    );
   }
 }

--- a/src/modules/project/project.repository.ts
+++ b/src/modules/project/project.repository.ts
@@ -6,6 +6,8 @@ import { errorMessages } from '../../common/enums/errorMessages';
 import { ServiceException } from '../../common/exception-filter/serviceException';
 import { UpdateProjectRequestDto } from './dtos/updateProjectRequest.dto';
 import { SearchProjectDto } from './dtos/searchProject.dto';
+import { ProjectWithRelations } from './types/project.types';
+import { SaveProjectRequestDto } from './dtos/saveProjectRequest.dto';
 
 @Injectable()
 export class ProjectRepository {
@@ -16,7 +18,7 @@ export class ProjectRepository {
    * @param id - The id of the Project to find
    * @returns A promise resolving to a Project object or null
    */
-  async findProjectById(id: number): Promise<Project> {
+  async findProjectById(id: number): Promise<ProjectWithRelations | null> {
     try {
       return await this.prisma.project.findUnique({
         where: {
@@ -30,6 +32,17 @@ export class ProjectRepository {
               password: true,
               passwordSalt: true,
               passwordChangedAt: true,
+            },
+          },
+          savedByUsers: {
+            include: {
+              user: {
+                omit: {
+                  password: true,
+                  passwordSalt: true,
+                  passwordChangedAt: true,
+                },
+              },
             },
           },
         },
@@ -321,6 +334,80 @@ export class ProjectRepository {
     } catch (error) {
       throw ServiceException.ErrorException(
         errorMessages.ERROR_DELETING_PROJECTS,
+        error,
+      );
+    }
+  }
+
+  /**
+   * Save a Project by userId
+   * @param projectId - The id of the Project to save
+   * @param saveProjectDto - The data transfer object containing saved users Id
+   * @returns A promise resolving to a Project object or null
+   */
+  async saveProject(
+    projectId: number,
+    saveProjectDto: SaveProjectRequestDto,
+  ): Promise<ProjectWithRelations | null> {
+    const { saved_by_users } = saveProjectDto;
+    try {
+      return await this.prisma.project.update({
+        where: {
+          id: projectId,
+        },
+        data: {
+          savedByUsers: {
+            deleteMany: {},
+            create: saved_by_users.map((userId) => ({
+              user: { connect: { id: userId } },
+            })),
+          },
+        },
+        include: {
+          language: true,
+          users: {
+            omit: {
+              password: true,
+              passwordSalt: true,
+              passwordChangedAt: true,
+            },
+          },
+          founder: {
+            omit: {
+              password: true,
+              passwordSalt: true,
+              passwordChangedAt: true,
+            },
+          },
+          domainLabels: {
+            include: {
+              label: true,
+            },
+          },
+          technicalLabels: {
+            include: {
+              label: true,
+            },
+          },
+          like: true,
+          involvement: true,
+          joinRequest: true,
+          savedByUsers: {
+            include: {
+              user: {
+                omit: {
+                  password: true,
+                  passwordSalt: true,
+                  passwordChangedAt: true,
+                },
+              },
+            },
+          },
+        },
+      });
+    } catch (error) {
+      throw ServiceException.ErrorException(
+        errorMessages.ERROR_SAVING_PROJECTS,
         error,
       );
     }

--- a/src/modules/project/project.service.ts
+++ b/src/modules/project/project.service.ts
@@ -1,4 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
+import { UserRepository } from '../user/user.repository';
 import { ProjectRepository } from './project.repository';
 import { ProjectMapper } from './dtos/project.mapper';
 import { errorMessages } from '../../common/enums/errorMessages';
@@ -15,10 +16,12 @@ import { ProjectResponseDto } from './dtos/projectResponse.dto';
 import { CreateProjectRequestDto } from './dtos/createProjectRequest.dto';
 import { UpdateProjectRequestDto } from './dtos/updateProjectRequest.dto';
 import { SearchProjectDto } from './dtos/searchProject.dto';
+import { SaveProjectRequestDto } from './dtos/saveProjectRequest.dto';
 
 @Injectable()
 export class ProjectService {
   constructor(
+    private userRepository: UserRepository,
     private projectRepository: ProjectRepository,
     private projectMapper: ProjectMapper,
     private readonly userService: UserService,
@@ -206,5 +209,75 @@ export class ProjectService {
     await this.redisService.flushDb();
 
     return this.projectMapper.projectToProjectResponseDto(deletedProject);
+  }
+
+  /**
+   * Saves a project
+   * @param projectId - project Id to be saved
+   * @param saveProjectDto - The data transfer object for saving a project
+   * @param userId - user Id requested to save the project
+   * @returns A promise resolving to a ProjectResponseDto
+   */
+  async saveProject(
+    projectId: number,
+    saveProjectDto: SaveProjectRequestDto,
+    userId: number,
+  ): Promise<ProjectResponseDto> {
+    const savingProject =
+      await this.projectRepository.findProjectById(projectId);
+
+    if (!savingProject) {
+      throw ServiceException.EntityNotFoundException(
+        errorMessages.ENTITY_NOT_FOUND('Project', projectId.toString()),
+      );
+    }
+
+    // Check saved_by_users array if each user id exists
+    for (const id of saveProjectDto.saved_by_users) {
+      const user = await this.userRepository.getUserById(id);
+      if (!user) {
+        throw ServiceException.EntityNotFoundException(
+          errorMessages.ENTITY_NOT_FOUND('User', id.toString()),
+        );
+      }
+    }
+
+    // create savedUsers Id array from database and check if current user already exists in saved users array
+    const savedUsersArr = [];
+    for (const user of savingProject.savedByUsers) {
+      if (user.userId === userId) {
+        throw ServiceException.BadRequestException(
+          errorMessages.USER_ALREADY_SAVED_PROJECT,
+        );
+      }
+      savedUsersArr.push(user.userId);
+    }
+
+    // add savedUsers Id array to saveProjectDto
+    saveProjectDto.saved_by_users = [
+      ...saveProjectDto.saved_by_users,
+      ...savedUsersArr,
+    ];
+
+    // add current user Id if current user doesn't exist in saveProjectDto
+    if (!saveProjectDto.saved_by_users.includes(userId)) {
+      saveProjectDto.saved_by_users = [
+        ...saveProjectDto.saved_by_users,
+        userId,
+      ];
+    }
+
+    // remove duplication
+    saveProjectDto.saved_by_users = [...new Set(saveProjectDto.saved_by_users)];
+
+    const savedProject = await this.projectRepository.saveProject(
+      projectId,
+      saveProjectDto,
+    );
+
+    //cache invalidation
+    await this.redisService.flushDb();
+
+    return this.projectMapper.projectToProjectResponseDto(savedProject);
   }
 }

--- a/src/modules/project/types/project.types.ts
+++ b/src/modules/project/types/project.types.ts
@@ -3,11 +3,12 @@ import {
   JoinRequest,
   Language,
   Like,
+  Prisma,
   Project,
   ProjectDomainLabel,
   ProjectTechnicalLabel,
-  User,
 } from '@prisma/client';
+import { UserWithoutSensitiveData } from '../../../../src/modules/user/types/user.types';
 
 export type ProjectWithLabels = Project & {
   domainLabels?: (ProjectDomainLabel & {
@@ -17,9 +18,44 @@ export type ProjectWithLabels = Project & {
     label: { name: string };
   })[];
   language?: Language;
-  users?: User[];
-  founder?: User;
+  users?: UserWithoutSensitiveData[];
+  founder?: UserWithoutSensitiveData;
   like?: Like[];
   involvement?: Involvement[];
   joinRequest?: JoinRequest[];
+  savedByUsers?: {
+    savedAt: Date;
+    user: UserWithoutSensitiveData;
+  }[];
 };
+
+export type ProjectWithRelations = Prisma.ProjectGetPayload<{
+  include: {
+    language: true;
+    users: {
+      omit: {
+        password: true;
+        passwordSalt: true;
+        passwordChangedAt: true;
+      };
+    };
+    founder: {
+      omit: {
+        password: true;
+        passwordSalt: true;
+        passwordChangedAt: true;
+      };
+    };
+    savedByUsers: {
+      include: {
+        user: {
+          omit: {
+            password: true;
+            passwordSalt: true;
+            passwordChangedAt: true;
+          };
+        };
+      };
+    };
+  };
+}>;

--- a/src/modules/user/types/user.types.ts
+++ b/src/modules/user/types/user.types.ts
@@ -1,0 +1,6 @@
+import { User } from '@think-storm/contracts';
+
+export type UserWithoutSensitiveData = Omit<
+  User,
+  'password' | 'passwordSalt' | 'passwordChangedAt'
+>;

--- a/test/e2e/project.e2e-spec.ts
+++ b/test/e2e/project.e2e-spec.ts
@@ -24,6 +24,8 @@ import { ThrottlerGuard } from '@nestjs/throttler';
 import { RedisThrottlerStorageService } from '../../src/common/throttler/redisThrottlerStorage.service';
 import { RedisService } from '../../src/common/caching/redisCaching.service';
 import { LanguageCode, stringToEnum } from '@think-storm/contracts';
+import { errorMessages } from '../../src/common/enums/errorMessages';
+
 describe('/projects', () => {
   let app: INestApplication;
   let prismaService: PrismaService;
@@ -489,6 +491,125 @@ describe('/projects', () => {
         .delete(`/${unauthorizedDeleteRequest.id}`)
         .set('Authorization', token)
         .expect(403);
+    });
+  });
+
+  describe('/projects/:id/save POST (Save Project)', () => {
+    it('should successfully save a project', async () => {
+      // Create a user
+      const registerResponse = await request(app.getHttpServer())
+        .post('/register')
+        .send(defaultCreateUserDto)
+        .expect(201);
+
+      // Create a project
+      const createdProject = await createProjectInDB(
+        prismaService,
+        defaultCreateProjectDto,
+      );
+
+      // Login to get auth token
+      const loginResponse = await request(app.getHttpServer())
+        .post('/login')
+        .send({
+          email: defaultCreateUserDto.email,
+          password: defaultCreateUserDto.password,
+        })
+        .expect(200);
+
+      const token = loginResponse.headers.authorization;
+
+      // Save the project
+      const response = await request(app.getHttpServer())
+        .post(`/${createdProject.id}/save`)
+        .set('Authorization', token)
+        .send({ saved_by_users: [] })
+        .expect(201);
+
+      expect(response.body).toBeDefined();
+      expect(response.body.id).toBe(createdProject.id);
+      expect(response.body.savedByUsers).toHaveLength(1);
+      expect(response.body.savedByUsers[0].userId).toBe(
+        registerResponse.body.id,
+      );
+    });
+
+    it('should return 401 when not authenticated', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/1/save')
+        .send({ saved_by_users: [] })
+        .expect(401);
+
+      expect(response.body.message).toBe(errorMessages.PROTECT_ROUTES);
+    });
+
+    it('should return 404 when project does not exist', async () => {
+      // Create and login a user first
+      await request(app.getHttpServer())
+        .post('/register')
+        .send(defaultCreateUserDto)
+        .expect(201);
+
+      const loginResponse = await request(app.getHttpServer())
+        .post('/login')
+        .send({
+          email: defaultCreateUserDto.email,
+          password: defaultCreateUserDto.password,
+        })
+        .expect(200);
+
+      const token = loginResponse.headers.authorization;
+
+      const response = await request(app.getHttpServer())
+        .post('/999/save')
+        .set('Authorization', token)
+        .send({ saved_by_users: [] })
+        .expect(404);
+
+      expect(response.body.message).toBe(
+        errorMessages.ENTITY_NOT_FOUND('Project', '999'),
+      );
+    });
+
+    it('should return 400 when project is already saved by user', async () => {
+      // Create a user
+      const registerResponse = await request(app.getHttpServer())
+        .post('/register')
+        .send(defaultCreateUserDto)
+        .expect(201);
+
+      // Create a project
+      const createdProject = await createProjectInDB(
+        prismaService,
+        defaultCreateProjectDto,
+      );
+
+      // Login to get auth token
+      const loginResponse = await request(app.getHttpServer())
+        .post('/login')
+        .send({
+          email: defaultCreateUserDto.email,
+          password: defaultCreateUserDto.password,
+        })
+        .expect(200);
+
+      const token = loginResponse.headers.authorization;
+
+      // Save the project first time
+      await request(app.getHttpServer())
+        .post(`/${createdProject.id}/save`)
+        .set('Authorization', token)
+        .send({ saved_by_users: [registerResponse.body.data.id] })
+        .expect(201);
+
+      // Try to save again
+      const response = await request(app.getHttpServer())
+        .post(`/${createdProject.id}/save`)
+        .set('Authorization', token)
+        .send({ saved_by_users: [registerResponse.body.data.id] })
+        .expect(400);
+
+      expect(response.body.message).toContain('already saved');
     });
   });
 });

--- a/test/unit/modules/project/dtos/project.mapper.spec.ts
+++ b/test/unit/modules/project/dtos/project.mapper.spec.ts
@@ -54,7 +54,6 @@ describe('ProjectMapper', () => {
 
   describe('projectToProjectResponseDto', () => {
     it('should map a Project with complex labels to ProjectResponseDto', () => {
-      // Create a Project with complex domain and technical labels
       const projectWithLabels: MockProjectWithLabels = {
         ...defaultProject,
         goal: Goal.Education,
@@ -71,11 +70,7 @@ describe('ProjectMapper', () => {
         ],
         technicalLabels: [
           { projectId: 1, labelName: 'nestjs', label: { name: 'nestjs' } },
-          {
-            projectId: 1,
-            labelName: 'js',
-            label: { name: 'js' },
-          },
+          { projectId: 1, labelName: 'js', label: { name: 'js' } },
           { projectId: 1, labelName: 'jest', label: { name: 'jest' } },
         ],
         language: {
@@ -86,6 +81,7 @@ describe('ProjectMapper', () => {
         },
         founder: defaultUser,
         users: [],
+        savedByUsers: [],
       };
 
       const expectedDto = {
@@ -107,15 +103,13 @@ describe('ProjectMapper', () => {
         createdAt: new Date('2000-01-01'),
         lastUpdatedAt: new Date('2000-01-01'),
         founder: defaultUser,
+        savedByUsers: [],
       };
 
       const result = projectMapper.projectToProjectResponseDto(
         projectWithLabels as any,
       );
-
-      expect(result).toEqual(expectedDto);
-      expect(result.domainLabels).toEqual(['Cooking', 'Design', 'Geography']);
-      expect(result.technicalLabels).toEqual(['nestjs', 'js', 'jest']);
+      expect(result).toEqual(expect.objectContaining(expectedDto));
     });
 
     it('should handle a Project without complex labels', () => {

--- a/test/unit/modules/project/project.controller.spec.ts
+++ b/test/unit/modules/project/project.controller.spec.ts
@@ -6,6 +6,7 @@ import { ProjectMapper } from '../../../../src/modules/project/dtos/project.mapp
 import {
   defaultCreateProjectDto,
   defaultDeleteProjectDto,
+  defaultProject,
   defaultProjectResponseDto,
   defaultSearchProjectDto,
   defaultUpdateProjectDto,
@@ -20,7 +21,7 @@ import { UserRepository } from '../../../../src/modules/user/user.repository';
 import { UserMapper } from '../../../../src/modules/user/dtos/user.mapper';
 import { PasswordEncryption } from '../../../../src/common/encryption/passwordEncryption';
 import { mockJwtToken } from '../../../utils/jwt.utils';
-import { defaultUserResponseDto } from '../../../utils/user.utils';
+import { defaultUser, defaultUserResponseDto } from '../../../utils/user.utils';
 import { createMockRequestWithUser } from '../../../utils/jwt.utils';
 import { JwtAuthGuard } from '../../../../src/modules/auth/jwt/jwt.guard';
 import { PrismaService } from '../../../../src/prisma/prisma.service';
@@ -31,6 +32,9 @@ import { RedisService } from '../../../../src/common/caching/redisCaching.servic
 import { CacheModule } from '@nestjs/cache-manager';
 import { cachingConfig } from '../../../../src/common/redis/redis.config';
 import * as redisStore from 'cache-manager-ioredis';
+import { ServiceException } from '../../../../src/common/exception-filter/serviceException';
+import { SaveProjectRequestDto } from '../../../../src/modules/project/dtos/saveProjectRequest.dto';
+import { errorMessages } from '../../../../src/common/enums/errorMessages';
 
 describe('ProjectController', () => {
   let projectController: ProjectController;
@@ -201,6 +205,60 @@ describe('ProjectController', () => {
         defaultDeleteProjectDto, // Body parameter
         mockRequest.user.id, // User ID from request
       );
+    });
+  });
+
+  describe('saveProject', () => {
+    it('should save project successfully', async () => {
+      const mockRequest = createMockRequestWithUser(
+        defaultUserResponseDto,
+      ) as any;
+      mockRequest.headers = createAuthHeader(mockJwtToken);
+      mockRequest.user = { id: defaultUser.id };
+
+      const saveProjectDto: SaveProjectRequestDto = {
+        saved_by_users: [],
+      };
+
+      const serviceSpy = jest
+        .spyOn(projectService, 'saveProject')
+        .mockResolvedValue(defaultProjectResponseDto);
+
+      const result = await projectController.saveProject(
+        defaultProject.id,
+        saveProjectDto,
+        mockRequest.user,
+      );
+
+      expect(result).toEqual(defaultProjectResponseDto);
+      expect(serviceSpy).toHaveBeenCalledWith(
+        defaultProject.id,
+        saveProjectDto,
+        mockRequest.user.id,
+      );
+    });
+
+    it('should handle errors from service layer', async () => {
+      const mockRequest = createMockRequestWithUser(
+        defaultUserResponseDto,
+      ) as any;
+      mockRequest.user = { id: defaultUser.id };
+
+      jest
+        .spyOn(projectService, 'saveProject')
+        .mockRejectedValue(
+          ServiceException.EntityNotFoundException(
+            errorMessages.ENTITY_NOT_FOUND('project', '999'),
+          ),
+        );
+
+      await expect(
+        projectController.saveProject(
+          999,
+          { saved_by_users: [] },
+          mockRequest.user,
+        ),
+      ).rejects.toThrow(ServiceException);
     });
   });
 });

--- a/test/unit/modules/project/project.repository.spec.ts
+++ b/test/unit/modules/project/project.repository.spec.ts
@@ -25,6 +25,7 @@ import refreshDatabase from '../../../../src/prisma/prisma.dbreset';
 import { ProjectWithLabels } from '../../../../src/modules/project/types/project.types';
 import { ServiceException } from '../../../../src/common/exception-filter/serviceException';
 import { errorMessages } from '../../../../src/common/enums/errorMessages';
+import { SaveProjectRequestDto } from '../../../../src/modules/project/dtos/saveProjectRequest.dto';
 
 describe('ProjectRepository', () => {
   let prismaService: PrismaService;
@@ -285,6 +286,45 @@ describe('ProjectRepository', () => {
       ).toStrictEqual(
         projectTobeDeleted.technicalLabels.map((dl) => dl.labelName).sort(),
       );
+    });
+  });
+
+  describe('saveProject', () => {
+    it('should save project successfully', async () => {
+      // Create initial test data
+      const user = await userRepository.createUser(
+        defaultCreateUserDto,
+        defaultPasswordSalt,
+      );
+
+      const project = await createProjectInDB(
+        prismaService,
+        defaultCreateProjectDto,
+      );
+
+      const saveProjectDto: SaveProjectRequestDto = {
+        saved_by_users: [user.id],
+      };
+
+      const savedProject = await projectRepository.saveProject(
+        project.id,
+        saveProjectDto,
+      );
+
+      expect(savedProject).toBeDefined();
+      expect(savedProject.id).toBe(project.id);
+      expect(savedProject.savedByUsers).toHaveLength(1);
+      expect(savedProject.savedByUsers[0].userId).toBe(user.id);
+    });
+
+    it('should handle errors when saving project', async () => {
+      const saveProjectDto: SaveProjectRequestDto = {
+        saved_by_users: [999],
+      };
+
+      await expect(
+        projectRepository.saveProject(999, saveProjectDto),
+      ).rejects.toThrow(ServiceException);
     });
   });
 });

--- a/test/unit/modules/project/project.service.spec.ts
+++ b/test/unit/modules/project/project.service.spec.ts
@@ -24,16 +24,18 @@ import { PrismaModule } from '../../../../src/prisma/prisma.module';
 import { UserRepository } from '../../../../src/modules/user/user.repository';
 import { UserMapper } from '../../../../src/modules/user/dtos/user.mapper';
 import { PasswordEncryption } from '../../../../src/common/encryption/passwordEncryption';
-import { LanguageName } from '@think-storm/contracts';
+import { LanguageCode, LanguageName } from '@think-storm/contracts';
 import { ProjectResponseDto } from '../../../../src/modules/project/dtos/projectResponse.dto';
 import { RedisService } from '../../../../src/common/caching/redisCaching.service';
 import { CacheModule } from '@nestjs/cache-manager';
 import { cachingConfig } from '../../../../src/common/redis/redis.config';
 import * as redisStore from 'cache-manager-ioredis';
+import { SaveProjectRequestDto } from '../../../../src/modules/project/dtos/saveProjectRequest.dto';
 
 describe('ProjectService', () => {
   let projectService: ProjectService;
   let projectRepository: ProjectRepository;
+  let userRepository: UserRepository;
   let projectMapper: ProjectMapper;
   let userService: UserService;
   let redisService: RedisService;
@@ -70,6 +72,7 @@ describe('ProjectService', () => {
     projectRepository = module.get<ProjectRepository>(ProjectRepository);
     projectMapper = module.get<ProjectMapper>(ProjectMapper);
     userService = module.get<UserService>(UserService);
+    userRepository = module.get<UserRepository>(UserRepository);
     redisService = module.get<RedisService>(RedisService);
   });
 
@@ -213,55 +216,82 @@ describe('ProjectService', () => {
     });
 
     it('should return a project if project exists with id', async () => {
-      // Mock call to DB to return a Project
+      const mockProject = {
+        ...defaultProject,
+        language: {
+          code: defaultProject.languageCode,
+          name: LanguageName.English,
+          createdAt: new Date(),
+          lastUpdatedAt: new Date(),
+        },
+        users: [],
+        founder: defaultUser,
+        savedByUsers: [],
+        domainLabels: [],
+        technicalLabels: [],
+      };
+
       const spy = jest
         .spyOn(projectRepository, 'findProjectById')
-        .mockResolvedValue(defaultProject);
+        .mockResolvedValue(mockProject);
 
-      expect(() => {
-        const getProjectResponseDto = projectService.getProjectById(
-          defaultProjectResponseDto.id,
-        );
+      const result = await projectService.getProjectById(
+        defaultProjectResponseDto.id,
+      );
 
-        // Checking the mapper
-        expect(getProjectResponseDto).not.toHaveProperty('founderId');
-      }).not.toThrow();
-
-      expect(spy).toHaveBeenCalledTimes(1);
+      expect(result).toBeDefined();
       expect(spy).toHaveBeenCalledWith(defaultProjectResponseDto.id);
     });
   });
 
   describe('createProject', () => {
     it('should create user and map the result into UserResponseDto', async () => {
-      // Mock call to the password and salt creation
-      const userSpy = jest
-        .spyOn(userService, 'getUserById')
-        .mockResolvedValue(defaultUser);
+      jest.spyOn(userService, 'getUserById').mockResolvedValue(defaultUser);
 
-      // Mock call to DB
-      const dbSpy = jest
+      const mockProject = {
+        ...defaultProject,
+        language: {
+          code: defaultProject.languageCode,
+          name: LanguageName.English,
+          createdAt: new Date(),
+          lastUpdatedAt: new Date(),
+        },
+        users: [],
+        founder: defaultUser,
+        savedByUsers: [],
+        domainLabels: [],
+        technicalLabels: [],
+      };
+
+      jest
         .spyOn(projectRepository, 'createProject')
-        .mockResolvedValue(defaultProject);
+        .mockResolvedValue(mockProject);
 
-      const expectedResponseDto = defaultProjectResponseDto;
-      expectedResponseDto.founder = undefined;
-      expectedResponseDto.language = undefined;
-      expectedResponseDto.users = undefined;
-      expectedResponseDto.technicalLabels = undefined;
-      expectedResponseDto.domainLabels = undefined;
-
-      const projectResponseDto = await projectService.createProject(
+      const result = await projectService.createProject(
         defaultCreateProjectDto,
       );
 
-      // Checking the mapper
-      expect(projectResponseDto).toEqual(expectedResponseDto);
-
-      expect(userSpy).toHaveBeenCalledTimes(1);
-
-      expect(dbSpy).toHaveBeenCalledTimes(1);
-      expect(dbSpy).toHaveBeenCalledWith(defaultCreateProjectDto);
+      expect(result).toEqual({
+        id: mockProject.id,
+        title: mockProject.title,
+        description: mockProject.description,
+        goal: mockProject.goal,
+        status: mockProject.status,
+        users: [],
+        founder: defaultUser,
+        language: {
+          code: LanguageCode.EN,
+          name: LanguageName.English,
+          createdAt: expect.any(Date),
+          lastUpdatedAt: expect.any(Date),
+        },
+        savedByUsers: [],
+        domainLabels: [],
+        technicalLabels: [],
+        createdAt: mockProject.createdAt,
+        lastUpdatedAt: mockProject.lastUpdatedAt,
+        milestone: mockProject.milestone,
+      });
     });
   });
 
@@ -292,10 +322,25 @@ describe('ProjectService', () => {
     });
 
     it('should throw an 403 exception if the user is not the owner of the project', async () => {
+      const mockProject = {
+        ...defaultProject,
+        language: {
+          code: defaultProject.languageCode,
+          name: LanguageName.English,
+          createdAt: new Date(),
+          lastUpdatedAt: new Date(),
+        },
+        users: [],
+        founder: defaultUser,
+        savedByUsers: [],
+        domainLabels: [],
+        technicalLabels: [],
+      };
+
       // Mock call to DB to return a Project
       const spy = jest
         .spyOn(projectRepository, 'findProjectById')
-        .mockResolvedValue(defaultProject);
+        .mockResolvedValue(mockProject);
 
       try {
         await projectService.updateProject(defaultUpdateProjectDto, 999);
@@ -321,10 +366,13 @@ describe('ProjectService', () => {
           lastUpdatedAt: new Date(),
         },
         users: [],
+        founder: defaultUser,
+        savedByUsers: [],
         domainLabels: [],
         technicalLabels: [],
-        founderId: defaultUpdateProjectDto.founderId,
-        founder: defaultUser,
+        like: [],
+        involvement: [],
+        joinRequest: [],
       };
 
       const spy = jest
@@ -347,6 +395,7 @@ describe('ProjectService', () => {
           lastUpdatedAt: expect.any(Date),
         },
         founder: defaultUser,
+        savedByUsers: [],
       };
 
       const projectResponseDto = await projectService.updateProject(
@@ -392,10 +441,25 @@ describe('ProjectService', () => {
     });
 
     it('should throw an 403 exception if the user is not the owner of the project', async () => {
+      const mockProject = {
+        ...defaultProject,
+        language: {
+          code: defaultProject.languageCode,
+          name: LanguageName.English,
+          createdAt: new Date(),
+          lastUpdatedAt: new Date(),
+        },
+        users: [],
+        founder: defaultUser,
+        savedByUsers: [],
+        domainLabels: [],
+        technicalLabels: [],
+      };
+
       // Mock call to DB to return a Project
       const spy = jest
         .spyOn(projectRepository, 'findProjectById')
-        .mockResolvedValue(defaultProject);
+        .mockResolvedValue(mockProject);
 
       try {
         await projectService.deleteProject(defaultDeleteProjectDto, 999);
@@ -418,13 +482,14 @@ describe('ProjectService', () => {
         language: {
           code: defaultProject.languageCode,
           name: LanguageName.English,
-          createdAt: currentDate,
-          lastUpdatedAt: currentDate,
+          createdAt: new Date(),
+          lastUpdatedAt: new Date(),
         },
         users: [],
+        founder: defaultUser,
+        savedByUsers: [],
         domainLabels: [],
         technicalLabels: [],
-        founder: defaultUser,
       };
 
       const spy = jest
@@ -447,6 +512,7 @@ describe('ProjectService', () => {
         domainLabels: [],
         technicalLabels: [],
         founder: defaultUser,
+        savedByUsers: [],
       };
 
       const projectResponseDto = await projectService.deleteProject(
@@ -462,6 +528,139 @@ describe('ProjectService', () => {
 
       expect(dbSpy).toHaveBeenCalledTimes(1);
       expect(dbSpy).toHaveBeenCalledWith(defaultDeleteProjectDto.id);
+    });
+  });
+
+  describe('saveProject', () => {
+    const mockUserId = 1;
+
+    it('should save project when project exists and user has not saved it', async () => {
+      const mockProject = {
+        ...defaultProject,
+        language: {
+          code: defaultProject.languageCode,
+          name: LanguageName.English,
+          createdAt: new Date(),
+          lastUpdatedAt: new Date(),
+        },
+        users: [],
+        founder: defaultUser,
+        savedByUsers: [],
+        domainLabels: [],
+        technicalLabels: [],
+      };
+
+      const saveProjectDto: SaveProjectRequestDto = {
+        saved_by_users: [],
+      };
+
+      const findProjectSpy = jest
+        .spyOn(projectRepository, 'findProjectById')
+        .mockResolvedValue(mockProject);
+
+      jest.spyOn(userRepository, 'getUserById').mockResolvedValue(defaultUser);
+
+      const saveSpy = jest
+        .spyOn(projectRepository, 'saveProject')
+        .mockResolvedValue(mockProject);
+
+      const result = await projectService.saveProject(
+        defaultProject.id,
+        saveProjectDto,
+        mockUserId,
+      );
+
+      expect(result).toBeDefined();
+      expect(findProjectSpy).toHaveBeenCalledWith(defaultProject.id);
+      expect(saveSpy).toHaveBeenCalledWith(defaultProject.id, {
+        saved_by_users: [mockUserId],
+      });
+    });
+
+    it('should throw error when project does not exist', async () => {
+      jest.spyOn(projectRepository, 'findProjectById').mockResolvedValue(null);
+
+      await expect(
+        projectService.saveProject(999, { saved_by_users: [] }, mockUserId),
+      ).rejects.toThrow(ServiceException);
+    });
+
+    it('should throw error when user has already saved project', async () => {
+      const mockProject = {
+        ...defaultProject,
+        language: {
+          code: defaultProject.languageCode,
+          name: LanguageName.English,
+          createdAt: new Date(),
+          lastUpdatedAt: new Date(),
+        },
+        users: [],
+        founder: defaultUser,
+        savedByUsers: [
+          {
+            projectId: defaultProject.id,
+            userId: mockUserId,
+            savedAt: new Date(),
+            user: {
+              id: mockUserId,
+              email: 'test@test.com',
+              username: 'testuser',
+              fullName: 'Test User',
+              birthdate: new Date(),
+              createdAt: new Date(),
+              lastUpdatedAt: new Date(),
+            },
+          },
+        ],
+        domainLabels: [],
+        technicalLabels: [],
+        like: [],
+        involvement: [],
+        joinRequest: [],
+      };
+
+      jest
+        .spyOn(projectRepository, 'findProjectById')
+        .mockResolvedValue(mockProject);
+
+      await expect(
+        projectService.saveProject(
+          defaultProject.id,
+          { saved_by_users: [] },
+          mockUserId,
+        ),
+      ).rejects.toThrow(ServiceException);
+    });
+
+    it('should throw error when user in saved_by_users does not exist', async () => {
+      const mockProject = {
+        ...defaultProject,
+        language: {
+          code: defaultProject.languageCode,
+          name: LanguageName.English,
+          createdAt: new Date(),
+          lastUpdatedAt: new Date(),
+        },
+        users: [],
+        founder: defaultUser,
+        savedByUsers: [],
+        domainLabels: [],
+        technicalLabels: [],
+      };
+
+      jest
+        .spyOn(projectRepository, 'findProjectById')
+        .mockResolvedValue(mockProject);
+
+      jest.spyOn(userRepository, 'getUserById').mockResolvedValue(null);
+
+      await expect(
+        projectService.saveProject(
+          defaultProject.id,
+          { saved_by_users: [999] },
+          mockUserId,
+        ),
+      ).rejects.toThrow(ServiceException);
     });
   });
 });

--- a/test/utils/project.utils.ts
+++ b/test/utils/project.utils.ts
@@ -16,6 +16,7 @@ import { defaultPasswordSalt } from '../../test/unit/common/passwordEncryption.u
 import { SearchProjectDto } from '../../src/modules/project/dtos/searchProject.dto';
 import { GetProjectRequestDto } from '../../src/modules/project/dtos/getProjectRequest.dto';
 import { SearchProjectResponseDto } from './../../src/modules/project/dtos/searchProjectResponse.dto';
+import { ProjectWithLabels } from './../../src/modules/project/types/project.types';
 
 export const createProjectInDB = async (
   prismaService: PrismaService,
@@ -177,7 +178,7 @@ export const defaultProjectResponseDto: ProjectResponseDto = {
   founder: defaultUser,
 };
 
-export const defaultProject: Project = {
+export const defaultProject: ProjectWithLabels = {
   id: 1,
   founderId: 1,
   title: 'title',
@@ -188,6 +189,20 @@ export const defaultProject: Project = {
   milestone: new Date('2000-01-01'),
   createdAt: new Date('2000-01-01'),
   lastUpdatedAt: new Date('2000-01-01'),
+  savedByUsers: [],
+  language: {
+    code: LanguageCode.EN,
+    name: LanguageName.English,
+    createdAt: new Date(),
+    lastUpdatedAt: new Date(),
+  },
+  users: [],
+  founder: defaultUser,
+  domainLabels: [],
+  technicalLabels: [],
+  like: [],
+  involvement: [],
+  joinRequest: [],
 };
 
 export const secondProject: Project = {
@@ -326,6 +341,7 @@ export type MockProjectWithLabels = {
     lastUpdatedAt: Date;
   } | null;
   founder?: typeof defaultUser;
+  savedByUsers?: any[];
   users?: any[];
   like?: any[];
   involvement?: any[];


### PR DESCRIPTION
## Related Issue

- save project api

## Description

added save project api logic and add unit tests and e2e test for save project api so that user can save projects that they chose.

## Details

1.  save project api
<hr/>
 Thinking process for this api

  - [x] user should be logged in
  - [x] project that was selected must exist (otherwise, Not found error)
  - [x] users that are in saved_by_users array must exist (otherwise, Not found error)
  - [x] check if current user ID exists in original users array that saved selected projct (otherwise, Bad request error)
  - [x] add original users array ids that saved project to saved_by_users array
  - [x] add current user ID to saved_by_users array (if it was already added, go to next step)
  - [x] remove duplicated IDs from saved_by_users array 

<hr/>

According to this logic, I changed prisma schema like this.
- [x] add savedByUsers field to Project
- [x] add savedProjects field to User
- [x] add relation table SavedProject (with savedAt field)

<hr/>
2. add unit test for save project api

- [x] tested each case mentioned above for save project api
<hr/>
3. add e2e test for save project api

- [x] tested each case mentioned above for save project api
<hr/>

## Reviewers

- @Harian-Elyoth 
- @minju25kim 
